### PR TITLE
Fallback whitespace

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,6 @@
     "wrap-iife": 2,
     "new-cap": 2,
     "no-caller": 2,
-    "quotes": [1, "single"],
     "no-loop-func": 2,
     "no-irregular-whitespace": 1,
     "no-multi-spaces": 2,

--- a/lib/autolog.js
+++ b/lib/autolog.js
@@ -1,4 +1,6 @@
-var redis = require('./redis');
+'use strict';
+
+const redis = require('./redis');
 
 function shallowClone (o) {
 	return require('util')._extend({}, o);
@@ -14,16 +16,18 @@ module.exports = function(res) {
 	};
 
 	newRes.fail = function(message) {
+
+		// Log the failure, wit to see if a new message is forthcoming
 		redis.log(res, message, false)
-			.then(function (newMessage) {
-				origSend.apply(res, [newMessage]);
-			}, function (err) {
+		.then(function (newMessage) {
+			origSend.apply(res, [newMessage]);
+		}, function (err) {
 
-				if (err) console.error(err);
+			if (err) console.error(err);
 
-				// No custom message forthcoming so send the default message.
-				origSend.apply(res, [message]);
-			});
+			// No custom message forthcoming so send the default message.
+			origSend.apply(res, [message]);
+		});
 	};
 
 	newRes.send = function(...message) {

--- a/lib/ftapis.js
+++ b/lib/ftapis.js
@@ -1,16 +1,16 @@
 
 var API = {};
 
-API.pricing       = require('./apis/miod');
-API.shorturls     = require('./apis/bitly');
-API.share         = require('./apis/emailthis');
+API.pricing = require('./apis/miod');
+API.shorturls = require('./apis/bitly');
+API.share = require('./apis/emailthis');
 API.primaryThemes = require('./apis/slurp');
-API.topicsuggest  = require('./apis/next-topicsuggest');
-API.search        = require('./apis/next-search');
-API.follow        = require('./apis/next-follow');
-API.content       = require('./apis/capi');
+API.topicsuggest = require('./apis/next-topicsuggest');
+API.search = require('./apis/next-search');
+API.follow = require('./apis/next-follow');
+API.content = require('./apis/capi');
 
-API.listLength    = {
+API.listLength = {
 	short:  4,
 	long:  20
 };

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -20,7 +20,7 @@ var logLength = 5000;
 var logTrimInterval = 1000*3600; //Trim the logs hourly
 
 if (process.env.REDISTOGO_URL) {
-	var rtg   = require("url").parse(process.env.REDISTOGO_URL);
+	var rtg = require("url").parse(process.env.REDISTOGO_URL);
 	redis = Redis.createClient(rtg.port, rtg.hostname);
 	if (rtg.auth) redis.auth(rtg.auth.split(":")[1]);
 } else {
@@ -83,7 +83,7 @@ function log(res, response, fulfilled, options) {
 		if (fulfilled) return resolve();
 
 		// if no one is watching just send the default straight away
-		if (!res.robot.router.wss.respondersCount()) {
+		if (!res.robot.router.wss || !res.robot.router.wss.respondersCount()) {
 			return reject();
 		}
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "coffee-script": "^1.10.0",
     "hubot-test-helper": "^1.4.4",
     "mocha": "^2.5.3",
+    "nock": "^8.0.0",
     "sinon": "^1.17.4"
   }
 }

--- a/scripts/fallback.js
+++ b/scripts/fallback.js
@@ -20,9 +20,9 @@ module.exports = function (robot) {
 		name = this.name.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 		if (this.alias) {
 			alias = this.alias.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
-			newRegex = new RegExp("^\\s*[@]?(?:" + alias + "[:,]?|" + name + "[:,]?)\\s*(?:" + pattern + ")", modifiers);
+			newRegex = new RegExp("^\\s*[@]?(?:" + alias + "[:,]?|" + name + "[:,]?)\\s+(?:" + pattern + ")", modifiers);
 		} else {
-			newRegex = new RegExp("^\\s*[@]?" + name + "[:,]?\\s*(?:" + pattern + ")", modifiers);
+			newRegex = new RegExp("^\\s*[@]?" + name + "[:,]?\\s+(?:" + pattern + ")", modifiers);
 		}
 		return newRegex;
 	}).bind(robot);

--- a/scripts/help.js
+++ b/scripts/help.js
@@ -1,6 +1,14 @@
 // Description:
 //   Display a list of all valid commands, by scraping file header comments
 //   like this one from modules in the scripts folder
+// Dependencies:
+//
+// Commands:
+//   hubot help - display help message
+//   hubot help <command> - information about that command
+//   hubot help all - list all commands
+
+'use strict';
 
 // The structure is a list of sections,
 // where each section has a name and some descriptive text, e.g. *Basic Search*)
@@ -17,23 +25,26 @@ var fullHelpTemplate = [
 var bullet = "\u2022";
 
 var initialHelpTextLines = [
-'If interested in, say, apple:',
-bullet + ' search apple',
-bullet + ' price apple',
-bullet + ' recommend apple',
-bullet + ' topics apple',
-'For more on an article:',
-bullet + ' A2',
-'or a topic:',
-bullet + ' T1',
-bullet + ' follow T2',
-'More commands and details:',
-bullet + ' help all'
+	'If interested in, say, apple:',
+	bullet + ' search apple',
+	bullet + ' price apple',
+	bullet + ' recommend apple',
+	bullet + ' topics apple',
+	'For more on an article:',
+	bullet + ' A2',
+	'or a topic:',
+	bullet + ' T1',
+	bullet + ' follow T2',
+	'More commands and details:',
+	bullet + ' help all'
 ];
 
 module.exports = function(robot) {
 	robot.respond(/(?:h|help)(?:\s+(.*))?$/i, function(res) {
-		var cmds, emit, filter, prefix, lines;
+		let cmds;
+		let filter;
+		let prefix;
+		let lines;
 
 		// preprocess the cmds to have the relevant prefix - currently we prefer no name prefix, but conventionally it is `robot.alias || robot.name`
 		prefix = '';
@@ -78,8 +89,12 @@ module.exports = function(robot) {
 		return res.send(lines.join("\n"));
 	});
 
-	return robot.router.get("/" + robot.name + "/help", function(req, res) {
-		var cmds, emit;
+
+	if (robot.router.listen === undefined) return;
+
+	robot.router.get("/" + robot.name + "/help", function(req, res) {
+		let cmds;
+		let emit;
 		cmds = robot.helpCommands().map(function(cmd) {
 			return cmd.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 		});

--- a/scripts/logviewer.js
+++ b/scripts/logviewer.js
@@ -144,7 +144,7 @@ module.exports = function (robot) {
 	const app = robot.router;
 	const server = http.createServer(app);
 	robot.router = app;
-	app.listen(process.env.PORT);
+	server.listen(process.env.PORT);
 	console.log('Robot listening on port ' + process.env.PORT, '(process.env.PORT)');
 
 	// Set up Websockets on the server

--- a/scripts/logviewer.js
+++ b/scripts/logviewer.js
@@ -1,20 +1,22 @@
 // Description:
 //   Provides a web address where chat logs can be viewed and operators can interject
+// Commands
 
 // Dependencies
-var moment = require('moment');
-var exphbs  = require('express-handlebars');
-var IO = require('socket.io');
-var Wss = require('ws').Server;
-var redis = require('../lib/redis');
-var http = require('http');
-var fs = require('fs');
-var Handlebars = require('handlebars');
-var uniq = require('uniq');
+const moment = require('moment');
+const exphbs = require('express-handlebars');
+const socketio = require('socket.io');
+const redis = require('../lib/redis');
+const http = require('http');
+const fs = require('fs');
+const Handlebars = require('handlebars');
+const uniq = require('uniq');
 
-var API_ENDPOINTS_REDIS_KEY = 'apiEndpoints';
-var apiEndpoints = [];
-var logTemplate;
+'use strict';
+
+const API_ENDPOINTS_REDIS_KEY = 'apiEndpoints';
+const apiEndpoints = [];
+let logTemplate;
 
 fs.readFile('./views/partials/log.handlebars', { encoding: "utf8" }, function (err, data) {
 	if (err) throw err;
@@ -26,9 +28,11 @@ function updateApiEndpoints(cb) {
 		redis.redis.get(API_ENDPOINTS_REDIS_KEY, function (err, data) {
 			if (err) throw err;
 			if (!data) {
-				apiEndpoints = [];
+				apiEndpoints.splice(0);
 			} else {
-				apiEndpoints = uniq(apiEndpoints.concat(JSON.parse(data)));
+				apiEndpoints.splice(0);
+				apiEndpoints.push(...JSON.parse(data));
+				uniq(apiEndpoints);
 			}
 			if (cb) cb(apiEndpoints);
 		});
@@ -51,7 +55,7 @@ function setupWebsocketServer(server, robot) {
 	var heartbeatN = 1;
 
 	// Setup websockets to run on the same http server
-	io = IO(server);
+	io = socketio(server);
 
 	setInterval(function heartbeat() {
 		io.emit('heartbeat', { id: heartbeatN++ });
@@ -88,13 +92,13 @@ function setupWebsocketServer(server, robot) {
 	io.on('connection', function(ws) {
 		console.log('websocket connection open');
 
-		ws.on('endpoint', function(url) {
+		ws.on('endpoint', function(data) {
 			if (apiEndpoints.indexOf(data.endpoint.toLowerCase()) === -1) {
 				apiEndpoints.push(data.endpoint.toLowerCase());
 			}
 			storeApiEndpoints();
 		});
-		ws.on('removeEndpoint', function(url) {
+		ws.on('removeEndpoint', function(data) {
 			apiEndpoints = apiEndpoints.filter(function (val) {
 				return val.toLowerCase() !== data.endpoint.toLowerCase();
 			});
@@ -127,21 +131,20 @@ function setupWebsocketServer(server, robot) {
 }
 
 module.exports = function (robot) {
-	var app = robot.router;
-	var server;
-
 	// Fetch a list of all of the websocket endpoints to be passed to the client
 	updateApiEndpoints();
 
 	// Save the robot on exit
 	process.on('SIGTERM', robot.brain.save);
 
-	// REVIEW:AB: Doesn't hubot do this itself?
-	// The bot runs on the EXPRESS_PORT forward requests to it.
-	server = http.createServer(robot.router);
-
-	// Get the server to listen on the HEROKU port
-	server.listen(process.env.PORT);
+	// Hubots internal server does not expose the http server to attach an IO listener.
+	// So we need to create a new server and proxy the requests to it.
+	// hubots internal server's port is not exposed
+	if (robot.router.listen === undefined) return;
+	const app = robot.router;
+	const server = http.createServer(app);
+	robot.router = app;
+	app.listen(process.env.PORT);
 	console.log('Robot listening on port ' + process.env.PORT, '(process.env.PORT)');
 
 	// Set up Websockets on the server
@@ -188,11 +191,11 @@ module.exports = function (robot) {
 
 				res.render('logs', {
 					logs: replies.reverse().map(function (itemString) {
-							var item = JSON.parse(itemString);
-							item.robotTime = moment(item.timestamp, 'x').format();
-							item.humanTime = moment(item.timestamp, 'x').format('lll');
-							return item;
-						}),
+						const item = JSON.parse(itemString);
+						item.robotTime = moment(item.timestamp, 'x').format();
+						item.humanTime = moment(item.timestamp, 'x').format('lll');
+						return item;
+					}),
 					websocketApiLocations: apiEndpoints
 				});
 			});

--- a/scripts/onboarding.js
+++ b/scripts/onboarding.js
@@ -1,9 +1,9 @@
 // Description:
 //   Send a welcome message to new users.
+'use strict';
 
-var SEEN_LOG_PREFIX = "USER_SEEN_V0.12_";
-
-var onboardMessage = [  '*Welcome to the FT Bot*.',
+const SEEN_LOG_PREFIX = "USER_SEEN_V0.12_";
+const onboardMessage = [ '*Welcome to the FT Bot*.',
 						'I am a robot, not a real person, but I can help connect you with content and services from the Financial Times. Try saying ',
 						'`price apple`',
 						'`search obama`',
@@ -21,11 +21,11 @@ function genKey(robot, user) {
 function dmWelcomeMessage(res) {
 
 	switch(res.robot.adapterName) {
-		case 'slack':
-			res.robot.send({room: res.message.user.name}, onboardMessage);
-			break;
-		default:
-			res.robot.send({user: res.message.user}, onboardMessage);
+	case 'slack':
+		res.robot.send({room: res.message.user.name}, onboardMessage);
+		break;
+	default:
+		res.robot.send({user: res.message.user}, onboardMessage);
 	}
 }
 
@@ -48,7 +48,8 @@ module.exports = function (robot) {
 };
 
 module.exports.onboard = function (res) {
-	var onboarded = false;
+	let onboarded = false;
+	if (process.env.NO_ONBOARDING) return false;
 	if (!res.robot.brain.get(genKey(res.robot, res.message.user))) {
 		dmWelcomeMessage(res);
 		onboarded = true;

--- a/scripts/recommend.js
+++ b/scripts/recommend.js
@@ -4,13 +4,16 @@
 // Commands:
 //   hubot recommend <company> - Displays analyst recommendations for <company> (can be a name or ticker symbol)
 
-var API = require("../lib/ftapis");
+'use strict';
+
+const API = require("../lib/ftapis");
 
 module.exports = function (robot) {
 
 	robot.respond(/recommend(?:\s+(.*))?/i, function (res) {
+
 		res = require('../lib/autolog')(res); // Log the query to the database
-		var term = res.match[1];
+		const term = res.match[1];
 
 		if (! term) {
 			res.send('You need to specify a company name, e.g. recommend apple');

--- a/scripts/webinterface.js
+++ b/scripts/webinterface.js
@@ -5,6 +5,8 @@ var webinterfaces = require('../lib/webinterfaces/');
 
 module.exports = function (robot) {
 
+	if (robot.router.listen === undefined) return;
+
 	if (process.env.HUBOT_WEB_ENDPOINTS) {
 		robot.Response = webinterfaces(robot).Response;
 	}

--- a/test/nock.js
+++ b/test/nock.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const nock = require('nock');
+module.exports.cleanAll = function cleanAll() {
+	nock.cleanAll();
+}
+module.exports.recommend = function recommendNock() {
+	nock('http://markets.ft.com/')
+	.get('/research/webservices/securities/v1/search')
+	.query(true)
+	.reply(200, {
+		"data": {
+			"searchResults": [
+				{
+					"symbol": "AAPL:NSQ",
+					"name": "Apple Inc",
+					"exchange": "Consolidated Issue Listed on NASDAQ Global Select ",
+					"exhangeCode": "NSQ",
+					"currency": "USD"
+				},
+				{
+					"symbol": "0R2V:LSE",
+					"name": "Apple Inc",
+					"exchange": "London Stock Exchange",
+					"exhangeCode": "LSE",
+					"currency": "CHF"
+				},
+				{
+					"symbol": "APGN:LSE",
+					"name": "Applegreen PLC",
+					"exchange": "London Stock Exchange",
+					"exhangeCode": "LSE",
+					"currency": "GBp"
+				},
+				{
+					"symbol": "APLE:NYQ",
+					"name": "Apple Hospitality REIT Inc",
+					"exchange": "New York Consolidated",
+					"exhangeCode": "NYQ",
+					"currency": "USD"
+				}
+			]
+		},
+		"timeGenerated": "2016-06-02T22:44:38"
+	});
+
+	nock('http://markets.ft.com/')
+	.get('/research/webservices/securities/v1/consensus-recommendations')
+	.query(true)
+	.reply(200, {
+		"data": {
+			"items": [
+				{
+					"symbolInput": "AAPL:NSQ",
+					"basic": {
+						"symbol": "AAPL:NSQ",
+						"name": "Apple Inc",
+						"exchange": "Consolidated Issue Listed on NASDAQ Global Select ",
+						"exhangeCode": "NSQ",
+						"currency": "USD"
+					},
+					"consensus": {
+						"smartText": "As of May 27, 2016, the consensus forecast amongst 51 polled investment analysts covering Apple Inc. advises that the company will outperform the market. This has been the consensus forecast since the sentiment of investment analysts deteriorated on Sep 29, 2011. The previous consensus forecast advised investors to purchase equity in Apple Inc..",
+						"consensus": [
+							{
+								"buy": 20,
+								"outperform": 20,
+								"hold": 11,
+								"underperform": 0,
+								"sell": 0,
+								"noOpinion": 0,
+								"date": "2016-06-02T00:00:00"
+							},
+							{
+								"buy": 19,
+								"outperform": 19,
+								"hold": 12,
+								"underperform": 0,
+								"sell": 0,
+								"noOpinion": 0,
+								"date": "2016-05-05T00:00:00"
+							},
+							{
+								"buy": 21,
+								"outperform": 19,
+								"hold": 11,
+								"underperform": 0,
+								"sell": 0,
+								"noOpinion": 0,
+								"date": "2016-04-07T00:00:00"
+							},
+							{
+								"buy": 20,
+								"outperform": 20,
+								"hold": 12,
+								"underperform": 0,
+								"sell": 0,
+								"noOpinion": 0,
+								"date": "2016-03-10T00:00:00"
+							},
+							{
+								"buy": 21,
+								"outperform": 19,
+								"hold": 15,
+								"underperform": 0,
+								"sell": 1,
+								"noOpinion": 0,
+								"date": "2015-06-02T00:00:00"
+							}
+						]
+					}
+				}
+			]
+		},
+		"timeGenerated": "2016-06-02T22:44:39"
+	});
+}

--- a/test/test.js
+++ b/test/test.js
@@ -39,17 +39,6 @@ More commands and details:
 		}).catch(e => done(e));
 	});
 
-	it("suggest angela merkel", function(done) {
-		const helper = new Helper('../scripts/search.js');
-		room = helper.createRoom();
-		const command = '@hubot ' + this.test.title;
-		co(function *() {
-			yield room.user.say('alice', command);
-			expect(room.messages.length).to.eql(2);
-			done();
-		}).catch(e => done(e));
-	});
-
 	it("good evening", function(done) {
 		const helper = new Helper('../scripts/polite.js');
 		room = helper.createRoom();
@@ -61,13 +50,24 @@ More commands and details:
 		}).catch(e => done(e));
 	});
 
-	it("recommend apple", function(done) {
-		const helper = new Helper('../scripts/recommend.js');
+	it("blahwithspace", function(done) {
+		const helper = new Helper('../scripts/search.js');
 		room = helper.createRoom();
 		const command = '@hubot ' + this.test.title;
 		co(function *() {
 			yield room.user.say('alice', command);
-			expect(room.messages.length).to.eql(2);
+			setTimeout(() => expect(room.messages.length).to.eql(2), 100);
+			done();
+		}).catch(e => done(e));
+	});
+
+	it("blahnospace", function(done) {
+		const helper = new Helper('../scripts/search.js');
+		room = helper.createRoom();
+		const command = '@hubot' + this.test.title;
+		co(function *() {
+			yield room.user.say('alice', command);
+			setTimeout(() => expect(room.messages.length).to.eql(2), 100);
 			done();
 		}).catch(e => done(e));
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -86,9 +86,7 @@ describe("Replies correctly to", function() {
 		const command = 'hubot ' + this.test.title;
 		co(function *() {
 			yield room.user.say('alice', command);
-			console.log(command);
-			yield waitABit(1000);
-			console.log(room.messages);
+			yield waitABit(10);
 			expect(room.messages).to.eql([
 				['alice', command],
 				['hubot', 'As of May 27, 2016, the consensus forecast amongst 51 polled investment analysts covering Apple Inc. advises that the company will outperform the market. This has been the consensus forecast since the sentiment of investment analysts deteriorated on Sep 29, 2011. The previous consensus forecast advised investors to purchase equity in Apple Inc..']


### PR DESCRIPTION
This is a subtle change, normally the ftbot will match anything beginning with it's name regardless of whitespace.

So if you have a word which begins with the bots name but ends in something nonsencical it would still say it could not understand, e.g.

We have two bots: 'ftbot' and 'ftbottest'

in messaging ftbottest, ftbot tries to respond by saying it does not understand.

This prevents that situation.
