### PR TITLE
Add issue template for future issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+This is the issue tracker for FT Labs' Chatbot.
+
+For reporting potential security issues please email ftlabs@ft.com
+-->
+### Problem
+Tell us what the problem is
+
+### Steps to reproduce
+1.
+2.
+3.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Proposed solution
+Tell us how you think this should be solved


### PR DESCRIPTION
<!--
This is the issue tracker for FT Labs' Chatbot.

For reporting potential security issues please email ftlabs@ft.com
-->
### Problem

Currently we don't have any template for creating issues/feature requests for our projects. This has the unfortunate side-effect of having low quality issues being created, which are not very helpful when returning to a project/issue after a period of absence.
### Steps to reproduce
1. Go to any ftlabs repository on github
2. Click the `New issue` button
### Expected behaviour

The issue body field should be filled with a markdown template.
### Actual behaviour

The issue body is empty.
### Proposed solution

Let's use Github's new `ISSUE_TEMPLATE.md` feature. Add a file named `ISSUE_TEMPLATE.md` to the root of the project, fill this file with the markdown we want as our issue template.
