### PR TITLE
Rest

### DIFF
--- a/lib/autolog.js
+++ b/lib/autolog.js
@@ -18,16 +18,18 @@ module.exports = function(res) {
 
 	newRes.fail = function(message) {
 
-		// Log the failure, wit to see if a new message is forthcoming
+		// Log the failure, wait to see if a new message is forthcoming
 		redis.log(res, message, false)
 		.then(function (newMessage) {
 			origSend.apply(res, [newMessage]);
+			res.finish();
 		}, function (err) {
 
 			if (err) console.error(err);
 
 			// No custom message forthcoming so send the default message.
 			origSend.apply(res, [message]);
+			res.finish();
 		});
 	};
 

--- a/lib/autolog.js
+++ b/lib/autolog.js
@@ -7,7 +7,8 @@ function shallowClone (o) {
 }
 
 module.exports = function(res) {
-	console.log("AUTOLOG: res.envelope.message=" + JSON.stringify(res.envelope.message));
+	const {user, text, id} = res.envelope.message;
+	console.log("AUTOLOG: res.envelope.message=" + JSON.stringify({user, text, id}));
 	var origSend = res.send;
 	var newRes = shallowClone(res);
 
@@ -29,6 +30,8 @@ module.exports = function(res) {
 			origSend.apply(res, [message]);
 		});
 	};
+
+	newRes.finish = res.finish.bind(res);
 
 	newRes.send = function(...message) {
 		redis.log(res, message, true);

--- a/lib/webinterfaces/index.coffee
+++ b/lib/webinterfaces/index.coffee
@@ -16,10 +16,6 @@ module.exports = (robot) ->
 				@send = (message) =>
 					@message.send(message);
 
-	# Set up the endpoints
-	require('./slack')(robot)
-	require('./websockets')(robot)
-
 	return {
 		Response: NewResponse
 	}

--- a/lib/webinterfaces/index.coffee
+++ b/lib/webinterfaces/index.coffee
@@ -15,6 +15,8 @@ module.exports = (robot) ->
 			if @message instanceof WebMessage
 				@send = (message) =>
 					@message.send(message);
+				@fail = (message) =>
+					@message.send(message);
 
 	return {
 		Response: NewResponse

--- a/lib/webinterfaces/rest/endpoints.js
+++ b/lib/webinterfaces/rest/endpoints.js
@@ -1,0 +1,26 @@
+
+var RestMessage = require('./restmessage');
+var urlencodedParser = require('body-parser').urlencoded({ extended: false });
+
+module.exports = function setUpRestEndpoints(robot) {
+	var app = robot.router;
+	var user = robot.brain.userForId(-1, {
+		room: 'web_channel',
+		name: 'anonymous_user'
+	});
+	app.post('/v1/rest', urlencodedParser, function(req, res) {
+		if (req.body.message) {
+
+			// prepend the robot name to make it a dm
+			var text = robot.name + ": " + req.body.message;
+
+			// Generate an id for the message
+			var id = Date.now();
+
+			// send the message to the hubot
+			robot.receive(
+				new RestMessage(user, text, id, res)
+			);
+		}
+	});
+};

--- a/lib/webinterfaces/rest/index.js
+++ b/lib/webinterfaces/rest/index.js
@@ -1,0 +1,3 @@
+
+// Set up the rest endpoints
+module.exports = require('./endpoints');

--- a/lib/webinterfaces/rest/restmessage.coffee
+++ b/lib/webinterfaces/rest/restmessage.coffee
@@ -14,8 +14,10 @@ class RestMessage extends WebMessage
 		@buffer = [];
 	send: (message) =>
 		@buffer.push(message);
+	dm: (message) =>
+		@buffer.push(message);
 	finish: () =>
 		super()
-		@res.send(@buffer.join('/n'));
+		@res.send(@buffer.join('\n'));
 
 module.exports = RestMessage

--- a/lib/webinterfaces/rest/restmessage.coffee
+++ b/lib/webinterfaces/rest/restmessage.coffee
@@ -1,0 +1,21 @@
+
+WebMessage = require('../webmessage')
+
+class RestMessage extends WebMessage
+
+	# Represents an incoming message from the web.
+	#
+	# user - A User instance that sent the message.
+	# text - A String message.
+	# id   - A String of the message ID.
+	# res  - http response object through which to reply
+	constructor: (@user, @text, @id, @res) ->
+		super @user, @text, @id, @res
+		@buffer = [];
+	send: (message) =>
+		@buffer.push(message);
+	finish: () =>
+		super()
+		@res.send(@buffer.join('/n'));
+
+module.exports = RestMessage

--- a/lib/webinterfaces/slack/index.js
+++ b/lib/webinterfaces/slack/index.js
@@ -1,3 +1,5 @@
 
 // Set up the slack endpoints
+// This enables the room to create an /ftbot slash command without installing the robot itself.
+
 module.exports = require('./slackendpoints');

--- a/scripts/behindTheScenes.js
+++ b/scripts/behindTheScenes.js
@@ -12,6 +12,7 @@ module.exports = function (robot) {
 	commands.push('__secret');
 	robot.respond(/__secret$/i, function (res) {
 		res.send('Available secret commands\n`' + commands.join('`\n`') + '`');
+		res.finish();
 	});
 
 	commands.push('__scope');
@@ -21,6 +22,7 @@ module.exports = function (robot) {
 		var scope = brain.scope;
 		console.log("DEBUG: behindTheScenes: __scope: scope=", scope, ", res=", res);
 		res.send('__Admin View:\n scope=' + scope);
+		res.finish();
 	});
 
 	commands.push('__redis stats');
@@ -29,13 +31,18 @@ module.exports = function (robot) {
 		// Log the query to the database
 		res = require('../lib/autolog')(res);
 
-		if (!redis.redis) return res.send('I don\'t seem to be connected to a Redis instance');
+		if (!redis.redis) {
+			res.send('I don\'t seem to be connected to a Redis instance');
+			return res.finish();
+		}
 
 		redis.redis.info('all', function (err, result) {
 			if (err) {
-				return res.send(err);
+				res.send(err);
+				return res.finish();
 			}
 			res.send(result);
+			res.finish()
 		});
 	});
 
@@ -48,9 +55,13 @@ module.exports = function (robot) {
 		// Log the query to the database
 		res = require('../lib/autolog')(res);
 
-		if (!redis.redis) return res.send('I don\'t seem to be connected to a Redis instance');
+		if (!redis.redis) {
+			res.send('I don\'t seem to be connected to a Redis instance');
+			return res.finish();
+		}
 
 		res.send('Are you sure you want to do that?');
+		res.finish();
 
 		robot.respond(/./i, function tempCatchAll(res) {
 			if (user === res.user) {
@@ -68,6 +79,7 @@ module.exports = function (robot) {
 				} else {
 					res.send('You didn\'t reply \'yes\' so I won\'t empty Redis');
 				}
+				res.finish();
 
 				// Remove listener once responded to.
 				robot.listeners = robot.listeners.filter(function (listener) {
@@ -87,9 +99,13 @@ module.exports = function (robot) {
 		// Log the query to the database
 		res = require('../lib/autolog')(res);
 
-		if (!redis.redis) return res.send('I don\'t seem to be connected to a Redis instance');
+		if (!redis.redis) {
+			res.send('I don\'t seem to be connected to a Redis instance');
+			return res.finish();
+		}
 
 		res.send('Are you sure you want to do clear the logs?');
+		res.finish();
 
 		robot.respond(/./i, function tempCatchAll(res) {
 			if (user === res.user) {
@@ -97,9 +113,11 @@ module.exports = function (robot) {
 					redis.emptyLogs(function (err) {
 						if (!err) return res.send('Logs cleared');
 						res.send(err);
+						res.finish();
 					});
 				} else {
 					res.send('You didn\'t reply \'yes\' so I won\'t clear the logs');
+					res.finish();
 				}
 
 				// Remove listener once responded to.
@@ -117,11 +135,18 @@ module.exports = function (robot) {
 		// Log the query to the database
 		res = require('../lib/autolog')(res);
 
-		if (!redis.redis) return res.send('I don\'t seem to be connected to a Redis instance');
+		if (!redis.redis) {
+			res.send('I don\'t seem to be connected to a Redis instance');
+			res.finish();
+		}
 
 		redis.trimLogs(function (err) {
-			if (!err) return res.send('Logs trimmed');
+			if (!err) {
+				res.send('Logs trimmed');
+				return res.finish();
+			}
 			res.send(err);
+			res.finish();
 		});
 	});
 
@@ -135,6 +160,7 @@ module.exports = function (robot) {
 
 		res.send("Number of matches: "+results.length+".  Showing up to 20.");
 		res.send(results.slice(0, 20).join('\n'));
+		res.finish();
 	});
 
 	commands.push('__brain rm [RegExp pattern]');
@@ -153,5 +179,6 @@ module.exports = function (robot) {
 		});
 
 		res.send('Removed '+count+' keys from the brain');
+		res.finish();
 	});
 };

--- a/scripts/define.js
+++ b/scripts/define.js
@@ -16,6 +16,7 @@ module.exports = function (robot) {
 
 		if (! term) {
 			res.send('You need to specify a term or phrase, e.g. define leverage');
+			res.finish();
 			return;
 		} else {
 			var termContext = require('../lib/scopedlist').getDefinitionContext(res);
@@ -24,9 +25,11 @@ module.exports = function (robot) {
 				.then(function(def) {
 					var defstr = "*"+term+"*:   "+def;
 					res.send(numbers(termContext.add(defstr)));
+					res.finish();
 				})
 				.catch(function(e) {
 					res.send('Unable to display definition for "'+term+'".');
+					res.finish();
 					console.log(e);
 				})
 			;

--- a/scripts/fallback.js
+++ b/scripts/fallback.js
@@ -3,6 +3,7 @@
 
 // Dependencies
 var onboard = require('./onboarding').onboard;
+var WebMessage = require('../lib/webinterfaces/webmessage');
 
 module.exports = function (robot) {
 
@@ -42,16 +43,19 @@ module.exports = function (robot) {
 			var failMessage = 'I don\'t know what that means.  Say `hi` to find out about me or `help` if you want to know everything I can do.';
 			var m;
 
-
-			res.message.finish();
 			if (res.message.text.match(/\`/)) {
 				res.send("Try again without the back-tick quotes.");
 			} else if (m = res.message.text.match(/^\@?ft(?:-bot)?[:,]?\s+(\@?ft(?:-bot)?)/)) {
 				res.send("In this channel you don't need to start your message with " + m[1]);
 			} else if (!onboard(res)) { // Send them the welcome message if they need it
 				// otherwise let them know their query went unfulfilled
-				res.fail(failMessage);
+				if (res.message instanceof WebMessage) {
+					res.message.send(failMessage);
+				} else {
+					res.fail(failMessage);
+				}
 			}
+			res.message.finish();
 		}
 	});
 };

--- a/scripts/fallback.js
+++ b/scripts/fallback.js
@@ -42,6 +42,8 @@ module.exports = function (robot) {
 			var failMessage = 'I don\'t know what that means.  Say `hi` to find out about me or `help` if you want to know everything I can do.';
 			var m;
 
+
+			res.finish();
 			if (res.message.text.match(/\`/)) {
 				res.send("Try again without the back-tick quotes.");
 			} else if (m = res.message.text.match(/^\@?ft(?:-bot)?[:,]?\s+(\@?ft(?:-bot)?)/)) {

--- a/scripts/fallback.js
+++ b/scripts/fallback.js
@@ -43,7 +43,7 @@ module.exports = function (robot) {
 			var m;
 
 
-			res.finish();
+			res.message.finish();
 			if (res.message.text.match(/\`/)) {
 				res.send("Try again without the back-tick quotes.");
 			} else if (m = res.message.text.match(/^\@?ft(?:-bot)?[:,]?\s+(\@?ft(?:-bot)?)/)) {

--- a/scripts/help.js
+++ b/scripts/help.js
@@ -41,6 +41,7 @@ var initialHelpTextLines = [
 
 module.exports = function(robot) {
 	robot.respond(/(?:h|help)(?:\s+(.*))?$/i, function(res) {
+
 		let cmds;
 		let filter;
 		let prefix;
@@ -82,13 +83,13 @@ module.exports = function(robot) {
 			});
 			if (lines.length === 0) {
 				res.send("No available commands match " + filter + '. To see all commands, help all');
+				res.finish();
 				return;
 			}
 		}
-
+		res.finish();
 		return res.send(lines.join("\n"));
 	});
-
 
 	if (robot.router.listen === undefined) return;
 

--- a/scripts/help.js
+++ b/scripts/help.js
@@ -83,12 +83,11 @@ module.exports = function(robot) {
 			});
 			if (lines.length === 0) {
 				res.send("No available commands match " + filter + '. To see all commands, help all');
-				res.finish();
-				return;
+				return res.finish();
 			}
 		}
-		res.finish();
-		return res.send(lines.join("\n"));
+		res.send(lines.join("\n"));
+		return res.finish();
 	});
 
 	if (robot.router.listen === undefined) return;

--- a/scripts/logviewer.js
+++ b/scripts/logviewer.js
@@ -3,6 +3,8 @@
 // Commands
 
 // Dependencies
+'use strict';
+
 const moment = require('moment');
 const exphbs = require('express-handlebars');
 const socketio = require('socket.io');
@@ -12,7 +14,6 @@ const fs = require('fs');
 const Handlebars = require('handlebars');
 const uniq = require('uniq');
 
-'use strict';
 
 const API_ENDPOINTS_REDIS_KEY = 'apiEndpoints';
 const apiEndpoints = [];

--- a/scripts/middleware.js
+++ b/scripts/middleware.js
@@ -1,0 +1,30 @@
+// Description:
+//   Allows messages to signal that they will not be responded to any more.
+
+'use strict';
+
+const hubot = require('hubot');
+
+module.exports = function (robot) {
+
+	const oldFinish = hubot.Message.prototype.finish;
+
+	hubot.Message.prototype.addEventListener = function (type, fn) {
+		if (!this._listeners) this._listeners = {};
+		if (!this._listeners[type]) this._listeners[type] = [];
+		this._listeners[type].push(fn);
+	}
+
+	hubot.Message.prototype.finish = function finish() {
+		if (this.done) return;
+		oldFinish.call(this);
+		if (this._listeners && this._listeners.finish) {
+			this._listeners.finish.forEach(fn => fn.bind(this)());
+		}
+	};
+
+	robot.receiveMiddleware(function(context, next, done) {
+		next(done);
+	});
+
+};

--- a/scripts/polite.js
+++ b/scripts/polite.js
@@ -12,6 +12,7 @@ module.exports = function (robot) {
 			"It's what I'm here for",
 			"Glad to help"
 		]));
+		res.finish();
 	});
 
 	robot.respond(/(bye|kthxbye|good\s*bye|(see|catch)\s+y(ou|a)\s+later|laters)$/i, function (res) {
@@ -20,6 +21,7 @@ module.exports = function (robot) {
 			"Goodbye",
 			"See you later"
 		]));
+		res.finish();
 	});
 
 	robot.respond(/(good\s+(morning|afternoon|evening)|hello\s+again)/i, function (res) {
@@ -28,10 +30,12 @@ module.exports = function (robot) {
 			"Hi",
 			"And to you"
 		]));
+		res.finish();
 	});
 
 	robot.respond(/(shut\s+up|stop|go\s+away|(fuck|sod|bugger)\s+off|quiet(\s+down)?)$/i, function (res) {
 		res.send("If you would like me to stop alerting, say `alerts off`.  If you want me to stop interacting with you at all, you can unfriend me or remove my integration on your instant message service.  If you are using a corporate chat system, consult your suppport team.");
+		res.finish();
 	});
 
 };

--- a/scripts/price.js
+++ b/scripts/price.js
@@ -19,6 +19,7 @@ module.exports = function (robot) {
 
 		if (! term) {
 			res.send('You need to specify a company name or ticker symbol, e.g. price apple, or price AAPL');
+			res.finish();
 			return;
 		} else {
 			res = require('../lib/progressfeedback')(res);	// Pricing can take a while, so mix in progress feedback behaviour
@@ -34,7 +35,9 @@ module.exports = function (robot) {
 				term = priceMatch.basic.symbol;
 			} else if (/^T\d+$/i.test(term) && topicMatch) {
 				if (topicMatch.indexOf('organisations:') !== 0) {
-					return res.send(term + ' is not an organisation topic.  Organisation topics start with `organisations:`');
+					res.send(term + ' is not an organisation topic.  Organisation topics start with `organisations:`');
+					res.finish();
+					return;
 				}
 				term = topicMatch;
 			}
@@ -49,10 +52,12 @@ module.exports = function (robot) {
 						.then(API.shorturls.shorten)
 						.then(function(chart) {
 							res.send(numbers(priceContext.add(company, priceIdentifier), priceDecorator) + " " + numberFormat(company.quote.lastPrice,2) + ", " + (company.quote.change1Day > 0 ? "\u25b2" : "\u25bc") + " " + numberFormat(company.quote.change1Day, 2) + (company.quote.volume ? ". Vol: " + numberFormat(company.quote.volume) : "") + ". Chart: " + chart);
+							res.finish();
 						});
 				})
 				.catch(function(e) {
 					res.send('Unable to provide pricing information for "'+term+'".');
+					res.finish();
 					console.log(e);
 				})
 			;

--- a/scripts/recommend.js
+++ b/scripts/recommend.js
@@ -17,6 +17,7 @@ module.exports = function (robot) {
 
 		if (! term) {
 			res.send('You need to specify a company name, e.g. recommend apple');
+			res.finish();
 			return;
 		} else {
 			API.pricing.findSymbol(term)
@@ -24,9 +25,11 @@ module.exports = function (robot) {
 				.then(function(advice) {
 					if (!advice.smartText) throw('No results for ' + term);
 					res.send(advice.smartText);
+					res.finish();
 				})
 				.catch(function(e) {
 					res.send('Unable to display analyst recommendations for "'+ term +'".');
+					res.finish();
 					console.log(e);
 				})
 			;

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -79,6 +79,7 @@ var handleSearch = function(res, term) {
 
 	if(! term) {
 		res.send('You need to specify a word or phrase to search for, or a topic id, e.g. search bear market, or search T2');
+		res.finish();
 		return;
 	} else if (topicContext.isValidIndex(term)) {
 		// handle a numbered tag
@@ -86,6 +87,7 @@ var handleSearch = function(res, term) {
 		term = topicContext.get(term);
 		if (!term) {
 			res.send('Unknown topic. Say `topics` to find out what topics I already found for you, or `topics something` to find one.');
+			res.finish();
 			return;
 		}
 	} else if (/^\w{2,5}\:\w{3}$/.test(term)) {
@@ -130,6 +132,7 @@ var handleSearch = function(res, term) {
 						} else {
 							res.send('No related topics for *' + term + '*');
 						}
+						res.finish();
 					}
 				});
 			} else {
@@ -142,12 +145,14 @@ var handleSearch = function(res, term) {
 						} else {
 							res.send('No topic suggestions for *' + term + '*');
 						}
+						res.finish();
 					}
 				});
 			}
 		})
 		.catch(function(err) {
 			res.send('Unable to load results for *' + term + '*');
+			res.finish();
 			console.log(err, err.stack);
 		})
 	;
@@ -169,8 +174,10 @@ module.exports = function (robot) {
 			if (suggestions.length > 0) {
 				suggestions = suggestions.slice(0,API.listLength.short);
 				res.send('FT topics matching *' + term + '*:\n' + numbers(topicContext.add(suggestions)) + '\nTo follow a topic, say for example `follow T3`');
+				res.finish();
 			} else {
 				res.send('Nothing found for *' + term + '*.  Try a topic, or the name of a company, industry or person.');
+				res.finish();
 			}
 		});
 	});
@@ -179,6 +186,7 @@ module.exports = function (robot) {
 		res = require('../lib/autolog')(res);
 		var mode = res.match[1];
 		res.send('You need to specify a search term or a topic, e.g. ' + mode + ' collapse, or ' + mode + ' T2');
+		res.finish();
 	});
 
 	robot.respond(/(latest|search)\s+(.*)$/i, handleSearch );
@@ -187,6 +195,7 @@ module.exports = function (robot) {
 		res = require('../lib/autolog')(res);
 		var mode = res.match[1];
 		res.send('You need to specify a topic, e.g. topic T3, or T3');
+		res.finish();
 	});
 
 	robot.respond(/(?:topic\s+T?|T)?\s*(\d+)/i, function(res) {
@@ -199,6 +208,7 @@ module.exports = function (robot) {
 		res = require('../lib/autolog')(res);
 		var mode = res.match[1];
 		res.send('You need to specify an article, e.g. article A3, or A3');
+		res.finish();
 	});
 
 	robot.respond(/(?:article\s+A?|A)\s*(\d+)/i, function (res) {
@@ -220,5 +230,7 @@ module.exports = function (robot) {
 
 			res.send(articleFullerFormatter(article) + topicDetails);
 		}
+
+		res.finish();
 	});
 };

--- a/scripts/share.js
+++ b/scripts/share.js
@@ -12,6 +12,7 @@ module.exports = function (robot) {
 	robot.respond(/share(\s+\S+)?$/, function(res) {
 		res = require('../lib/autolog')(res);
 		res.send('You need to specify an article to share and an email address to share it with, e.g. share A5 with joe@bloggs.com');
+		res.finish();
 	});
 
 	robot.respond(/share\s+(\#|number\s+)?(\w?\d+)(\s+with)?\s+([\w\d\s\.\-\@\+]+)/i, function (res) {
@@ -24,13 +25,19 @@ module.exports = function (robot) {
 		res = require('../lib/autolog')(res);
 
 		if (!storyContext.get(1)) {
-			return res.send("I don't know which story you're referring to. Use `search` to find some stories to share");
+			res.send("I don't know which story you're referring to. Use `search` to find some stories to share");
+			res.finish();
+			return;
 		} else if (!story) {
-			return res.send("The list of stories available to share is from 1 to "+storyContext.length+".  There is no story "+(storyNo));
+			res.send("The list of stories available to share is from 1 to "+storyContext.length+".  There is no story "+(storyNo));
+			res.finish();
+			return;
 		}
 
 		if (!emailPat.test(recip)) {
-			return res.send("Recipient must be an email address, but I didn't recognise '"+recip+"' as an email address.  Try again?");
+			res.send("Recipient must be an email address, but I didn't recognise '"+recip+"' as an email address.  Try again?");
+			res.finish();
+			return;
 		}
 
 		API.share.send(recip, story)
@@ -40,6 +47,9 @@ module.exports = function (robot) {
 			.catch(function(err) {
 				res.send("Sorry, a problem prevented your email from being sent");
 				console.log('Error sending email this: err: ', err);
+			})
+			.then(function () {
+				res.finish();
 			})
 		;
 	});

--- a/scripts/webinterface.js
+++ b/scripts/webinterface.js
@@ -1,5 +1,7 @@
 // Description:
 //	 Adds slash commands peudo-adapter interface for Slack
+//	 Sets up the websockets adapter for the web widget
+//   Sets up the rest api for interacting with the bot
 
 var webinterfaces = require('../lib/webinterfaces/');
 

--- a/scripts/webinterface.js
+++ b/scripts/webinterface.js
@@ -7,7 +7,14 @@ module.exports = function (robot) {
 
 	if (robot.router.listen === undefined) return;
 
+	robot.Response = webinterfaces(robot).Response;
+
+	// Always have the rest endpoint enabled;
+	require('../lib/webinterfaces/rest')(robot);
+
 	if (process.env.HUBOT_WEB_ENDPOINTS) {
-		robot.Response = webinterfaces(robot).Response;
+		// Set up endpoints which require WebSockets
+		require('../lib/webinterfaces/slack')(robot);
+		require('../lib/webinterfaces/websockets')(robot);
 	}
 };

--- a/scripts/zeitgeist.js
+++ b/scripts/zeitgeist.js
@@ -27,6 +27,9 @@ var handleZeitgeistRecency = function(recencyFnName, recencyText, res){
 	.catch(function(e) {
 		res.send('zeitgeist' + display_flavour + ': none');
 		console.log(e);
+	})
+	.then(function () {
+		res.finish();
 	});
 };
 


### PR DESCRIPTION
# Problem

Cannot tell when a response has finished, allow the ability to hook into response.finish() by attaching listeners.

This prevents rest like api endpoints such as the slash based api from sending more than a single message.
# Steps to reproduce

Try to resppond after a multipart message
Try writing tests which need to wait on an api call without mocking.
# Expected behaviour

A sensible api with callbacks should be available for detecting this.
# Actual behaviour

It isn't

Proposed solution

This pull request will allow general long form scripts to signal that they are finished and a response can be dispatched.

It also adds a simple rest endpoint which can be queried by sending post requests to /v1/rest
